### PR TITLE
Use executableArguments when launching the Godot process

### DIFF
--- a/GodotDebugSession/GodotDebugSession.cs
+++ b/GodotDebugSession/GodotDebugSession.cs
@@ -85,11 +85,12 @@ namespace GodotDebugSession
                 _debuggeeKilled = false;
 
                 string godotExecutablePath = (string)args.executable;
+                string[] executableArguments = args.executableArguments?.ToObject<string[]>() ?? Array.Empty<string>();
 
                 string godotProjectDir = (string)args.godotProjectDir;
 
                 var startInfo = new GodotDebuggerStartInfo(executionType, godotExecutablePath,
-                    processOutputListener: this, listenArgs) {WorkingDirectory = godotProjectDir};
+                    executableArguments, processOutputListener: this, listenArgs) {WorkingDirectory = godotProjectDir};
 
                 _session.Run(startInfo, _debuggerSessionOptions);
 

--- a/GodotDebugSession/GodotDebuggerSession.cs
+++ b/GodotDebugSession/GodotDebuggerSession.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.Sockets;
 using System.Net;
 using System.Threading.Tasks;
@@ -89,9 +90,11 @@ namespace GodotDebugSession
 
                         // Launch Godot to run the game and connect to our remote debugger
 
+                        string extraArgs = string.Join(" ", godotStartInfo.ExecutableArguments.Select(arg => arg.Contains(" ") ? $"\"{arg}\"" : arg));
+
                         var processStartInfo = new ProcessStartInfo(godotStartInfo.GodotExecutablePath)
                         {
-                            Arguments = $"--path {workingDir} --remote-debug {host}:{remoteDebugPort}",
+                            Arguments = $"--path {workingDir} --remote-debug {host}:{remoteDebugPort} {extraArgs}",
                             WorkingDirectory = workingDir,
                             RedirectStandardOutput = true,
                             RedirectStandardError = true,

--- a/GodotDebugSession/GodotDebuggerStartInfo.cs
+++ b/GodotDebugSession/GodotDebuggerStartInfo.cs
@@ -5,15 +5,18 @@ namespace GodotDebugSession
     public class GodotDebuggerStartInfo : SoftDebuggerStartInfo
     {
         public string GodotExecutablePath { get; }
+        public string[] ExecutableArguments { get; }
         public ExecutionType ExecutionType { get; }
         public IProcessOutputListener ProcessOutputListener { get; }
 
         public GodotDebuggerStartInfo(ExecutionType executionType, string godotExecutablePath,
-            IProcessOutputListener processOutputListener, SoftDebuggerRemoteArgs softDebuggerConnectArgs) :
+            string[] executableArguments, IProcessOutputListener processOutputListener,
+            SoftDebuggerRemoteArgs softDebuggerConnectArgs) :
             base(softDebuggerConnectArgs)
         {
             ExecutionType = executionType;
             GodotExecutablePath = godotExecutablePath;
+            ExecutableArguments = executableArguments;
             ProcessOutputListener = processOutputListener;
         }
     }


### PR DESCRIPTION
Fixes #19 