### PR TITLE
Use executableArguments when launching the Godot process with MedallionShell

### DIFF
--- a/GodotDebugSession/ActionTextWriter.cs
+++ b/GodotDebugSession/ActionTextWriter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace GodotDebugSession
+{
+    public class ActionTextWriter : TextWriter
+    {
+        private readonly StringBuilder buffer = new StringBuilder();
+
+        private Action<string> Writer { get; }
+
+        public ActionTextWriter(Action<string> writer)
+        {
+            Writer = writer;
+        }
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void Write(char value)
+        {
+            if (value == '\n')
+            {
+                Writer(buffer.ToString());
+                buffer.Clear();
+                return;
+            }
+
+            buffer.Append(value);
+        }
+    }
+}

--- a/GodotDebugSession/GodotDebugSession.cs
+++ b/GodotDebugSession/GodotDebugSession.cs
@@ -69,7 +69,7 @@ namespace GodotDebugSession
                     IPAddress address = Utilities.ResolveIPAddress(host);
                     if (address == null)
                     {
-                        SendErrorResponse(response, 3013, "Invalid address '{host}'.", new {host});
+                        SendErrorResponse(response, 3013, "Invalid address '{host}'.", new { host });
                         return;
                     }
 
@@ -85,11 +85,13 @@ namespace GodotDebugSession
                 _debuggeeKilled = false;
 
                 string godotExecutablePath = (string)args.executable;
+                string[] executableArguments = args.executableArguments?.ToObject<string[]>() ?? Array.Empty<string>();
 
                 string godotProjectDir = (string)args.godotProjectDir;
 
-                var startInfo = new GodotDebuggerStartInfo(executionType, godotExecutablePath,
-                    processOutputListener: this, listenArgs) {WorkingDirectory = godotProjectDir};
+                var startInfo = new GodotDebuggerStartInfo(executionType,
+                    godotExecutablePath, executableArguments, processOutputListener: this, listenArgs)
+                { WorkingDirectory = godotProjectDir };
 
                 _session.Run(startInfo, _debuggerSessionOptions);
 

--- a/GodotDebugSession/GodotDebugSession.csproj
+++ b/GodotDebugSession/GodotDebugSession.csproj
@@ -53,6 +53,7 @@
         <Compile Include="..\thirdparty\vscode-mono-debug\src\Utilities.cs">
           <Link>Utilities.cs</Link>
         </Compile>
+        <Compile Include="ActionTextWriter.cs" />
         <Compile Include="GodotDebuggerSession.cs" />
         <Compile Include="GodotDebuggerStartInfo.cs" />
         <Compile Include="GodotDebugSession.cs" />
@@ -79,6 +80,7 @@
     <ItemGroup>
       <PackageReference Include="GodotTools.IdeMessaging" Version="1.1.0" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+      <PackageReference Include="MedallionShell" Version="1.6.2" />
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/GodotDebugSession/GodotDebuggerStartInfo.cs
+++ b/GodotDebugSession/GodotDebuggerStartInfo.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Mono.Debugging.Soft;
 
 namespace GodotDebugSession
@@ -5,15 +6,18 @@ namespace GodotDebugSession
     public class GodotDebuggerStartInfo : SoftDebuggerStartInfo
     {
         public string GodotExecutablePath { get; }
+        public string[] ExecutableArguments { get; }
         public ExecutionType ExecutionType { get; }
         public IProcessOutputListener ProcessOutputListener { get; }
 
         public GodotDebuggerStartInfo(ExecutionType executionType, string godotExecutablePath,
-            IProcessOutputListener processOutputListener, SoftDebuggerRemoteArgs softDebuggerConnectArgs) :
+            string[] executableArguments, IProcessOutputListener processOutputListener,
+            SoftDebuggerRemoteArgs softDebuggerConnectArgs) :
             base(softDebuggerConnectArgs)
         {
             ExecutionType = executionType;
             GodotExecutablePath = godotExecutablePath;
+            ExecutableArguments = executableArguments;
             ProcessOutputListener = processOutputListener;
         }
     }
@@ -29,5 +33,18 @@ namespace GodotDebugSession
     {
         void ReceiveStdOut(string data);
         void ReceiveStdErr(string data);
+    }
+
+    public static class IProcessOutputListenerExtensions
+    {
+        public static TextWriter GetStdOutTextWriter(this IProcessOutputListener processOutputListener)
+        {
+            return new ActionTextWriter(processOutputListener.ReceiveStdOut);
+        }
+
+        public static TextWriter GetStdErrTextWriter(this IProcessOutputListener processOutputListener)
+        {
+            return new ActionTextWriter(processOutputListener.ReceiveStdErr);
+        }
     }
 }


### PR DESCRIPTION
Re-implements launching the Godot process with https://github.com/madelson/MedallionShell and provides the `executableArguments` to the command (fixes #19).

**MedallionShell** handles the escaping of the arguments.

---

This is an alternative implementation of #20 which should handle more edge cases escaping the arguments.