### PR TITLE
Add debug configuration to launch a specified scene

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
 				"command": "godot.csharp.generateAssets",
 				"title": "Generate Assets for Build and Debug",
 				"category": "C# Godot"
+			},
+			{
+				"command": "godot.csharp.selectProject",
+				"title": "Select Project",
+				"category": "C# Godot"
 			}
 		],
 		"breakpoints": [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"workspaceContains:**/project.godot",
 		"onDebugResolve:godot",
 		"onCommand:godot.csharp.selectProject",
-		"onCommand:godot.csharp.generateAssets"
+		"onCommand:godot.csharp.generateAssets",
+		"onCommand:godot.csharp.getLaunchScene"
 	],
 	"main": "./dist/extension.bundled.js",
 	"scripts": {
@@ -112,6 +113,9 @@
 				"linux": {
 					"runtime": "mono"
 				},
+				"variables": {
+					"SelectLaunchScene": "godot.csharp.getLaunchScene"
+				},
 				"configurationSnippets": [
 					{
 						"label": "C# Godot: Play in Editor Configuration",
@@ -136,6 +140,23 @@
 							"executableArguments": [
 								"--path",
 								"${workspaceRoot}"
+							]
+						}
+					},
+					{
+						"label": "C# Godot: Launch Configuration (Select Scene)",
+						"description": "Launch a C# Godot App with a debugger.",
+						"body": {
+							"name": "Launch (Select Scene)",
+							"type": "godot-mono",
+							"request": "launch",
+							"mode": "executable",
+							"preLaunchTask": "build",
+							"executable": "${1:<insert-godot-executable-path-here>}",
+							"executableArguments": [
+								"--path",
+								"${workspaceRoot}",
+								"${command:SelectLaunchScene}"
 							]
 						}
 					},

--- a/src/assets-generator/debug.ts
+++ b/src/assets-generator/debug.ts
@@ -39,6 +39,7 @@ function _createDebugConfigurations(godotExecutablePath: string | undefined): vs
 	return [
 		createPlayInEditorDebugConfiguration(),
 		createLaunchDebugConfiguration(godotExecutablePath),
+		createLaunchDebugConfiguration(godotExecutablePath, true),
 		createAttachDebugConfiguration(),
 	];
 }
@@ -53,11 +54,11 @@ export function createPlayInEditorDebugConfiguration(): vscode.DebugConfiguratio
 	};
 }
 
-export function createLaunchDebugConfiguration(godotExecutablePath: string | undefined): vscode.DebugConfiguration
+export function createLaunchDebugConfiguration(godotExecutablePath: string | undefined, canSelectScene: boolean = false): vscode.DebugConfiguration
 {
 	godotExecutablePath = godotExecutablePath ?? '<insert-godot-executable-path-here>';
 	return {
-		name: 'Launch',
+		name: `Launch${canSelectScene ? ' (Select Scene)' : ''}`,
 		type: 'godot-mono',
 		request: 'launch',
 		mode: 'executable',
@@ -68,6 +69,7 @@ export function createLaunchDebugConfiguration(godotExecutablePath: string | und
 		executableArguments: [
 			'--path',
 			'${workspaceRoot}',
+			...(canSelectScene ? ['${command:SelectLaunchScene}'] : []),
 		],
 	};
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { Client, Peer, MessageContent, MessageStatus, ILogger, IMessageHandler }
 import * as completion_provider from './completion-provider';
 import * as debug_provider from './debug-provider';
 import * as assets_provider from './assets-provider';
+import { getWorkspaceScenes } from './workspace-utils';
 import { fixPathForGodot } from './godot-utils';
 import { findProjectFiles, ProjectLocation, promptForProject } from './project-select';
 
@@ -126,10 +127,16 @@ export async function activate(context: vscode.ExtensionContext) {
 		await assets_provider.addAssets();
 	});
 	context.subscriptions.push(generateAssetsCommand);
+
+	// Setup get launch scene command
+	const getLaunchSceneCommand = vscode.commands.registerCommand('godot.csharp.getLaunchScene', () => {
+		return vscode.window.showQuickPick(getWorkspaceScenes(client?.getGodotProjectDir()));
+	});
+	context.subscriptions.push(getLaunchSceneCommand);
 }
 
 function setupProject(project: ProjectLocation, context: vscode.ExtensionContext) {
-	const statusBarPath:string = project.relativeProjectPath === '.' ? './'  : project.relativeProjectPath;
+	const statusBarPath: string = project.relativeProjectPath === '.' ? './' : project.relativeProjectPath;
 	statusBarItem.text = `$(folder) Godot Project: ${statusBarPath}`;
 	// Setup client
 	if (client !== undefined) {

--- a/src/godot-tools-messaging/client.ts
+++ b/src/godot-tools-messaging/client.ts
@@ -205,6 +205,7 @@ export class Peer implements Disposable {
 
 export class Client implements Disposable {
     identity: string;
+    projectDir: string;
     projectMetadataDir: string;
     metaFilePath: string;
     messageHandler: IMessageHandler;
@@ -223,9 +224,14 @@ export class Client implements Disposable {
         this.messageHandler = messageHandler;
         this.logger = logger;
 
+        this.projectDir = godotProjectDir;
         this.projectMetadataDir = path.join(godotProjectDir, '.mono', 'metadata');
 
         this.metaFilePath = path.join(this.projectMetadataDir, GodotIdeMetadata.defaultFileName);
+    }
+
+    getGodotProjectDir(): string {
+        return this.projectDir;
     }
 
     isConnected(): boolean {

--- a/src/workspace-utils.ts
+++ b/src/workspace-utils.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode';
+
+export async function getWorkspaceScenes(projectDirectory: string | undefined = undefined): Promise<string[]> {
+	const pattern: string = '**/*.tscn';
+	const include: vscode.GlobPattern = projectDirectory
+		? new vscode.RelativePattern(projectDirectory, pattern)
+		: pattern;
+	return vscode.workspace.findFiles(include)
+		.then(uris => uris.map(uri => uri.fsPath));
+}


### PR DESCRIPTION
A new **Launch** debug configuration that shows a selector to the user to choose among any of the `*.tscn` files in the workspace to use as the entrypoint instead of using the project's main scene.

While this doesn't automatically select the currently opened scene in the Godot editor, it might be enough for some. When the user starts a debugging session they are presented with a list of all the scenes in the workspace to allow them to select any of them.

https://user-images.githubusercontent.com/3903059/128580099-65e5c300-f56d-4eb0-8a7d-9524b9dc56d5.mp4

---

This PR is a draft because it depends on #22 
