### PR TITLE
Use local `webpack`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,12 @@ build-debug: $(GODOT_DEBUG_SESSION)-debug tsc-debug
 	@echo "build finished"
 
 tsc:
-	node_modules/.bin/tsc -p ./
-	webpack --mode production
+	./node_modules/.bin/tsc -p ./
+	./node_modules/.bin/webpack --mode production
 
 tsc-debug:
-	node_modules/.bin/tsc -p ./
-	webpack --mode development
+	./node_modules/.bin/tsc -p ./
+	./node_modules/.bin/webpack --mode development
 
 $(GODOT_DEBUG_SESSION):
 	msbuild /p:Configuration=Release $(SOLUTION_DIR)/GodotDebugSession.sln


### PR DESCRIPTION
Use the locally installed `webpack` dependency. This way the `webpack` dependency doesn't need to be installed globally and added to the PATH.