### PR TITLE
Add support for diffirrent Godot project paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"Other"
 	],
 	"activationEvents": [
-		"workspaceContains:project.godot",
+		"workspaceContains:**/project.godot",
 		"onDebugResolve:godot"
 	],
 	"main": "./dist/extension.bundled.js",

--- a/src/project-select.ts
+++ b/src/project-select.ts
@@ -1,0 +1,35 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+export interface ProjectLocation{
+    relativeFilePath: string
+    absoluteFilePath: string
+    relativeProjectPath: string
+    absoluteProjectPath: string
+}
+
+export async function findProjectFiles(): Promise<ProjectLocation[]> {
+    let projectFiles = await vscode.workspace.findFiles("**/project.godot");
+    return projectFiles.map((x) => {
+        return {
+            relativeFilePath: vscode.workspace.asRelativePath(x),
+            absoluteFilePath: x.path,
+            relativeProjectPath: path.dirname(vscode.workspace.asRelativePath(x)),
+            absoluteProjectPath: path.dirname(x.path)            
+        }
+    });
+}
+
+export async function promptForProject(): Promise<ProjectLocation | undefined> {
+    let godotProjectFiles = await findProjectFiles();
+    let selectionOptions = godotProjectFiles?.map((x) => {
+        return {
+            label: x.relativeFilePath,
+            ...x
+        }
+    });
+    return vscode.window.showQuickPick(selectionOptions, {
+        title: 'Select a Godot project',
+        placeHolder: 'Select a Godot project'
+    });
+}


### PR DESCRIPTION
The extension currently assumes that the project path for your Godot project is in the workspace folder root. This PR detects projects which may be nested in sub-folders and lets you choose which one to use.

**Dropdown for selecting the Godot project**
![project-selector](https://user-images.githubusercontent.com/3958783/134568512-76837652-0046-4129-b86f-56574d932c1b.png)

**Statusbar for showing current project**
![project-statusbar](https://user-images.githubusercontent.com/3958783/134568513-79a27c0b-be33-4225-b8da-ce8242e849c6.png)