### PR TITLE
Fix extension for 4.0

### DIFF
--- a/src/assets-generator/tasks.ts
+++ b/src/assets-generator/tasks.ts
@@ -19,7 +19,7 @@ export function createBuildTaskDescription(godotExecutablePath: string | undefin
 		label: 'build',
 		command: godotExecutablePath,
 		type: 'process',
-		args: ['--build-solutions', '--path', '${workspaceRoot}', '--no-window', '-q'],
+		args: ['--build-solutions', '--path', '${workspaceRoot}', '--no-window', '--quit'],
 		problemMatcher: '$msCompile',
 	};
 }

--- a/src/godot-tools-messaging/client.ts
+++ b/src/godot-tools-messaging/client.ts
@@ -225,7 +225,11 @@ export class Client implements Disposable {
         this.logger = logger;
 
         this.projectDir = godotProjectDir;
-        this.projectMetadataDir = path.join(godotProjectDir, '.mono', 'metadata');
+        this.projectMetadataDir = path.join(godotProjectDir, '.godot', 'mono', 'metadata');
+        if (!fs.existsSync(this.projectMetadataDir)) {
+            // Fallback for 3.x projects
+            this.projectMetadataDir = path.join(godotProjectDir, '.mono', 'metadata');
+        }
 
         this.metaFilePath = path.join(this.projectMetadataDir, GodotIdeMetadata.defaultFileName);
     }


### PR DESCRIPTION
- The `.mono` folder was moved to `.godot/mono` (https://github.com/godotengine/godot/pull/38704)
- The `--remote-debug` argument now requires the protocol (https://github.com/godotengine/godot/pull/37099)
- The `-q` argument has been repurposed, now `--quit` should be used (https://github.com/godotengine/godot/pull/55696)

Although these changes should fix the extension for 4.0 while keeping support for 3.x, they feel hacky and it might be better to simply provide a configuration setting for the user that defaults to the current stable version of Godot instead of trying to detect the version.

Closes #38