### PR TITLE
Fix Webpack Config for Newer NodeJS Versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
 		"tslint": "^5.12.1",
 		"typescript": "^3.3.1",
 		"vsce": "^1.20.0",
-		"webpack": "^4.43.0",
-		"webpack-cli": "^3.3.11"
+		"webpack": "^5.70.0",
+		"webpack-cli": "^4.9.2"
 	},
 	"breakpoints": [
 		{

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
 		"@types/node": "^16.4.1",
 		"@types/vscode": "^1.62.0",
 		"glob": "^7.1.4",
-		"make": "^0.8.1",
 		"mocha": "^6.1.4",
 		"ts-loader": "^7.0.5",
 		"tslint": "^5.12.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,8 +14,7 @@ const config = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'extension.bundled.js',
     libraryTarget: 'commonjs2',
-    devtoolModuleFilenameTemplate: '../[resource-path]',
-    hashFunction: 'xxhash64'
+    devtoolModuleFilenameTemplate: '../[resource-path]'
   },
   devtool: 'source-map',
   externals: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,8 @@ const config = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'extension.bundled.js',
     libraryTarget: 'commonjs2',
-    devtoolModuleFilenameTemplate: '../[resource-path]'
+    devtoolModuleFilenameTemplate: '../[resource-path]',
+    hashFunction: 'xxhash64'
   },
   devtool: 'source-map',
   externals: {


### PR DESCRIPTION
The current Webpack settings don't work well with the current LTS version (v17) as seen in this issue: https://github.com/webpack/webpack/issues/14532

Changes made in this PR will update the webpack configuration to work around this issue by adding a `hashFunction` to the `output`-setting.