### PR TITLE
Support metadata file with Windows new lines

### DIFF
--- a/src/godot-tools-messaging/client.ts
+++ b/src/godot-tools-messaging/client.ts
@@ -372,7 +372,7 @@ export class Client implements Disposable {
     readMetadataFile(): GodotIdeMetadata | undefined {
         const buffer = fs.readFileSync(this.metaFilePath);
         const metaFileContent = buffer.toString('utf-8');
-        const lines = metaFileContent.split('\n');
+        const lines = metaFileContent.replace('\r\n', '\n').split('\n');
 
         if (lines.length < 2) {
             return undefined;


### PR DESCRIPTION
Replace Windows new lines (`\r\n`) with Unix new lines (`\n`) before splitting so we can handle the metadata file as if it was using `\n` all along.

Fixes #51 