### PR TITLE
Add support for Godot 4.0

### DIFF
--- a/GodotDebugSession/GodotDebugSession.csproj
+++ b/GodotDebugSession/GodotDebugSession.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
     <PropertyGroup>
@@ -79,7 +79,7 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="GodotTools.IdeMessaging" Version="1.1.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="MedallionShell" Version="1.6.2" />
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "C# Tools for Godot",
 	"description": "Debugger and utilities for working with Godot C# projects",
 	"icon": "icon.png",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"publisher": "neikeq",
 	"license": "MIT",
 	"repository": {
@@ -36,32 +36,34 @@
 		"webpack-watch": "webpack --mode development --watch"
 	},
 	"dependencies": {
-		"async-file": "^2.0.2",
-		"chokidar": "^3.4.0",
-		"fs-extra": "^10.0.0",
-		"jsonc-parser": "^3.0.0",
-		"lookpath": "^1.2.1",
-		"promise-socket": "^6.0.3",
-		"vscode-debugprotocol": "^1.40.0"
+		"async-file": "2.0.2",
+		"chokidar": "3.4.0",
+		"fs-extra": "10.0.0",
+		"jsonc-parser": "3.0.0",
+		"lookpath": "1.2.1",
+		"promise-socket": "6.0.3",
+		"semver": "^7.3.8",
+		"vscode-debugprotocol": "1.40.0"
 	},
 	"extensionDependencies": [
 		"ms-dotnettools.csharp",
 		"ms-vscode.mono-debug"
 	],
 	"devDependencies": {
-		"@types/fs-extra": "^9.0.12",
-		"@types/glob": "^7.1.1",
-		"@types/mocha": "^5.2.6",
-		"@types/node": "^16.4.1",
-		"@types/vscode": "^1.62.0",
-		"glob": "^7.1.4",
-		"mocha": "^6.1.4",
-		"ts-loader": "^7.0.5",
-		"tslint": "^5.12.1",
-		"typescript": "^3.3.1",
-		"vsce": "^1.20.0",
-		"webpack": "^5.70.0",
-		"webpack-cli": "^4.9.2"
+		"@types/fs-extra": "9.0.12",
+		"@types/glob": "7.1.1",
+		"@types/mocha": "5.2.6",
+		"@types/node": "16.4.1",
+		"@types/semver": "^7.3.13",
+		"@types/vscode": "1.62.0",
+		"glob": "7.1.4",
+		"mocha": "6.1.4",
+		"ts-loader": "7.0.5",
+		"tslint": "5.12.1",
+		"typescript": "3.9.10",
+		"vsce": "1.20.0",
+		"webpack": "5.70.0",
+		"webpack-cli": "4.9.2"
 	},
 	"breakpoints": [
 		{
@@ -78,7 +80,18 @@
 				"godot.csharp.executablePath": {
 					"type": "string",
 					"default": null,
-					"description": "Path to the Godot engine executable."
+					"description": "Path to the Godot 3 engine executable.",
+					"deprecationMessage": "Use godot3ExecutablePath instead."
+				},
+				"godot.csharp.godot3ExecutablePath": {
+					"type": "string",
+					"default": null,
+					"description": "Path to the Godot 3 engine executable."
+				},
+				"godot.csharp.godot4ExecutablePath": {
+					"type": "string",
+					"default": null,
+					"description": "Path to the Godot 4 engine executable."
 				}
 			}
 		},
@@ -105,7 +118,7 @@
 		"debuggers": [
 			{
 				"type": "godot-mono",
-				"label": "C# Godot",
+				"label": "C# Godot 3",
 				"languages": [
 					"csharp",
 					"fsharp"
@@ -122,8 +135,8 @@
 				},
 				"configurationSnippets": [
 					{
-						"label": "C# Godot: Play in Editor Configuration",
-						"description": "Launch a C# Godot App from the open editor with a debugger.",
+						"label": "C# Godot 3: Play in Editor Configuration",
+						"description": "Launch a C# Godot 3 App from the open editor with a debugger.",
 						"body": {
 							"name": "Play in Editor",
 							"type": "godot-mono",
@@ -132,8 +145,8 @@
 						}
 					},
 					{
-						"label": "C# Godot: Launch Configuration",
-						"description": "Launch a C# Godot App with a debugger.",
+						"label": "C# Godot 3: Launch Configuration",
+						"description": "Launch a C# Godot 3 App with a debugger.",
 						"body": {
 							"name": "Launch",
 							"type": "godot-mono",
@@ -148,8 +161,8 @@
 						}
 					},
 					{
-						"label": "C# Godot: Launch Configuration (Select Scene)",
-						"description": "Launch a C# Godot App with a debugger.",
+						"label": "C# Godot 3: Launch Configuration (Select Scene)",
+						"description": "Launch a C# Godot 3 App with a debugger.",
 						"body": {
 							"name": "Launch (Select Scene)",
 							"type": "godot-mono",
@@ -165,7 +178,7 @@
 						}
 					},
 					{
-						"label": "C# Godot: Attach Configuration",
+						"label": "C# Godot 3: Attach Configuration",
 						"description": "Attach a debugger to a C# Godot App.",
 						"body": {
 							"name": "Attach",
@@ -226,6 +239,62 @@
 						}
 					}
 				}
+			},
+			{
+				"type": "godot-dotnet",
+				"label": "C# Godot 4",
+				"languages": [
+					"csharp",
+					"fsharp"
+				],
+				"configurationSnippets": [
+					{
+						"label": "C# Godot 4: Launch Configuration",
+						"description": "Launch a C# Godot 4 App with a debugger.",
+						"body": {
+							"name": "Launch",
+							"type": "coreclr",
+							"request": "launch",
+							"preLaunchTask": "build",
+							"program": "${1:<insert-godot-executable-path-here>}",
+							"args": [
+								"--path",
+								"${workspaceRoot}"
+							],
+							"cwd": "${workspaceRoot}",
+							"stopAtEntry": false,
+							"console": "internalConsole"
+						}
+					},
+					{
+						"label": "C# Godot 4: Launch Configuration (Select Scene)",
+						"description": "Launch a C# Godot 4 App with a debugger.",
+						"body": {
+							"name": "Launch (Select Scene)",
+							"type": "coreclr",
+							"request": "launch",
+							"preLaunchTask": "build",
+							"program": "${1:<insert-godot-executable-path-here>}",
+							"args": [
+								"--path",
+								"${workspaceRoot}",
+								"${command:godot.csharp.getLaunchScene}"
+							],
+							"cwd": "${workspaceRoot}",
+							"stopAtEntry": false,
+							"console": "internalConsole"
+						}
+					},
+					{
+						"label": "C# Godot 4: Attach Configuration",
+						"description": "Attach a debugger to a C# Godot 4 App.",
+						"body": {
+							"name": "Attach",
+							"type": "coreclr",
+							"request": "attach"
+						}
+					}
+				]
 			}
 		]
 	}

--- a/src/assets-generator/assets-generator.ts
+++ b/src/assets-generator/assets-generator.ts
@@ -28,12 +28,12 @@ export class AssetsGenerator {
 		return new AssetsGenerator(vscodeFolder);
 	}
 
-	public async addTasksJsonIfNecessary(): Promise<void> {
-		return addTasksJsonIfNecessary(this.tasksJsonPath);
+	public async addTasksJsonIfNecessary(godotVersion: string): Promise<void> {
+		return addTasksJsonIfNecessary(this.tasksJsonPath, godotVersion);
 	}
 
-	public async addLaunchJsonIfNecessary(): Promise<void> {
-		return addLaunchJsonIfNecessary(this.launchJsonPath);
+	public async addLaunchJsonIfNecessary(godotVersion: string): Promise<void> {
+		return addLaunchJsonIfNecessary(this.launchJsonPath, godotVersion);
 	}
 
 	public async hasExistingAssets(): Promise<boolean> {

--- a/src/assets-generator/tasks.ts
+++ b/src/assets-generator/tasks.ts
@@ -1,33 +1,62 @@
+import * as vscode from 'vscode';
 import * as tasks from 'vscode-tasks';
 import * as jsonc from 'jsonc-parser';
 import * as fs from 'fs-extra';
+import * as semver from 'semver';
 import {getFormattingOptions, replaceCommentPropertiesWithComments, updateJsonWithComments} from '../json-utils';
-import {findGodotExecutablePath} from '../godot-utils';
+import {findGodotExecutablePath, GODOT_VERSION_3, GODOT_VERSION_4} from '../godot-utils';
 
-export function createTasksConfiguration(godotExecutablePath: string | undefined): tasks.TaskConfiguration
+export function createTasksConfiguration(godotExecutablePath: string | undefined, godotVersion: string): tasks.TaskConfiguration
 {
 	return {
 		version: '2.0.0',
-		tasks: [createBuildTaskDescription(godotExecutablePath)],
+		tasks: _createTasksConfiguration(godotExecutablePath, godotVersion),
 	};
 }
 
-export function createBuildTaskDescription(godotExecutablePath: string | undefined): tasks.TaskDescription
+function _createTasksConfiguration(godotExecutablePath: string | undefined, godotVersion: string) : tasks.TaskDescription[] {	
+	if (semver.intersects(godotVersion, GODOT_VERSION_3)) {
+		return [
+			createBuildTaskDescriptionForGodot3(godotExecutablePath),
+		];
+	} else if (semver.intersects(godotVersion, GODOT_VERSION_4)) {
+		return [
+			createBuildTaskDescriptionForGodot4(godotExecutablePath),
+		];
+	} else {
+		vscode.window.showErrorMessage('Cannot create C# Godot tasks configurations. Godot version is unknown or unsupported.');
+		return [];
+	}
+}
+
+export function createBuildTaskDescriptionForGodot3(godotExecutablePath: string | undefined): tasks.TaskDescription
 {
 	godotExecutablePath = godotExecutablePath ?? '<insert-godot-executable-path-here>';
 	return {
 		label: 'build',
 		command: godotExecutablePath,
 		type: 'process',
-		args: ['--build-solutions', '--path', '${workspaceRoot}', '--no-window', '-q'],
+		args: ['--build-solutions', '--path', '${workspaceRoot}', '--no-window', '--quit'],
 		problemMatcher: '$msCompile',
 	};
 }
 
-export async function addTasksJsonIfNecessary(tasksJsonPath: string): Promise<void>
+export function createBuildTaskDescriptionForGodot4(godotExecutablePath: string | undefined): tasks.TaskDescription
 {
-	const godotExecutablePath = await findGodotExecutablePath();
-	const tasksConfiguration = createTasksConfiguration(godotExecutablePath);
+	godotExecutablePath = godotExecutablePath ?? '<insert-godot-executable-path-here>';
+	return {
+		label: 'build',
+		command: godotExecutablePath,
+		type: 'process',
+		args: ['--build-solutions', '--path', '${workspaceRoot}', '--headless', '--quit'],
+		problemMatcher: '$msCompile',
+	};
+}
+
+export async function addTasksJsonIfNecessary(tasksJsonPath: string, godotVersion: string): Promise<void>
+{
+	const godotExecutablePath = await findGodotExecutablePath(godotVersion);
+	const tasksConfiguration = createTasksConfiguration(godotExecutablePath, godotVersion);
 
 	const formattingOptions = getFormattingOptions();
 

--- a/src/assets-provider.ts
+++ b/src/assets-provider.ts
@@ -2,13 +2,20 @@ import * as vscode from 'vscode';
 import * as fs from 'fs-extra';
 import {getVscodeFolder} from './vscode-utils';
 import {AssetsGenerator} from './assets-generator';
+import {determineGodotVersion} from './godot-utils';
 
-export async function addAssets(): Promise<void>
+export async function addAssets(godotProjectDir: string | undefined = undefined): Promise<void>
 {
 	const vscodeFolder = getVscodeFolder();
 	if (!vscodeFolder)
 	{
 		vscode.window.showErrorMessage('Cannot generate C# Godot assets for build and debug. No workspace folder was selected.');
+		return;
+	}
+
+	const godotVersion = await determineGodotVersion(godotProjectDir);
+	if (!godotVersion) {
+		vscode.window.showErrorMessage('Cannot create C# Godot debug configurations. Godot version is unknown or unsupported.');
 		return;
 	}
 
@@ -24,8 +31,8 @@ export async function addAssets(): Promise<void>
 	await fs.ensureDir(vscodeFolder);
 
 	const promises = [
-		generator.addTasksJsonIfNecessary(),
-		generator.addLaunchJsonIfNecessary(),
+		generator.addTasksJsonIfNecessary(godotVersion),
+		generator.addLaunchJsonIfNecessary(godotVersion),
 	];
 
 	await Promise.all(promises);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -21,7 +21,8 @@ const DEFAULT_EXCEPTIONS: ExceptionConfigurations = {
 export class Configuration {
 	public static Value: Configuration = new Configuration();
 
-	public godotExecutablePath: string | undefined;
+	public godot3ExecutablePath: string | undefined;
+	public godot4ExecutablePath: string | undefined;
 
 	public exceptionOptions: ExceptionConfigurations = DEFAULT_EXCEPTIONS;
 
@@ -45,7 +46,8 @@ export class Configuration {
 		// Too lazy so we're re-using mono-debug extension settings for now...
 		const monoConfiguration = vscode.workspace.getConfiguration('mono-debug');
 
-		this.godotExecutablePath = godotConfiguration.get('executablePath');
+		this.godot3ExecutablePath = godotConfiguration.get('godot3ExecutablePath') || godotConfiguration.get('executablePath');
+		this.godot4ExecutablePath = godotConfiguration.get('godot4ExecutablePath');
 		this.exceptionOptions = monoConfiguration.get('exceptionOptions', DEFAULT_EXCEPTIONS);
 	}
 

--- a/src/godot-tools-messaging/client.ts
+++ b/src/godot-tools-messaging/client.ts
@@ -2,8 +2,10 @@ import * as net from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as chokidar from 'chokidar';
+import * as semver from 'semver';
 import PromiseSocket from 'promise-socket';
 import { Disposable } from 'vscode';
+import {GODOT_VERSION_3, GODOT_VERSION_4} from '../godot-utils';
 
 async function timeout(ms: number) {
     return new Promise(resolve => {
@@ -207,6 +209,7 @@ export class Client implements Disposable {
     identity: string;
     projectDir: string;
     projectMetadataDir: string;
+    godotVersion: string;
     metaFilePath: string;
     messageHandler: IMessageHandler;
     logger: ILogger;
@@ -219,13 +222,18 @@ export class Client implements Disposable {
 
     peer?: Peer;
 
-    constructor(identity: string, godotProjectDir: string, messageHandler: IMessageHandler, logger: ILogger) {
+    constructor(identity: string, godotProjectDir: string, godotVersion: string, messageHandler: IMessageHandler, logger: ILogger) {
         this.identity = identity;
         this.messageHandler = messageHandler;
         this.logger = logger;
 
         this.projectDir = godotProjectDir;
-        this.projectMetadataDir = path.join(godotProjectDir, '.mono', 'metadata');
+        this.godotVersion = godotVersion;
+        if (semver.intersects(godotVersion, GODOT_VERSION_3)) {
+            this.projectMetadataDir = path.join(godotProjectDir, '.mono', 'metadata');
+        } else { // GODOT_VERSION_4+
+            this.projectMetadataDir = path.join(godotProjectDir, '.godot', 'mono', 'metadata');
+        }
 
         this.metaFilePath = path.join(this.projectMetadataDir, GodotIdeMetadata.defaultFileName);
     }

--- a/src/godot-utils.ts
+++ b/src/godot-utils.ts
@@ -1,6 +1,69 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as readline from 'readline';
+import * as path from 'path';
+import * as semver from 'semver';
 import {lookpath} from 'lookpath';
 import {Configuration} from './configuration';
 import {client} from './extension';
+import {findProjectFiles} from './project-select';
+
+export const GODOT_VERSION_3 = '3.*.*';
+export const GODOT_VERSION_4 = '4.*.*';
+
+export async function determineGodotVersion(folder: vscode.WorkspaceFolder | string | undefined): Promise<string | undefined> {
+    if (folder) {
+        // Try to determine Godot version from the project folder
+        const folderPath = typeof folder === 'string' ? folder : folder.uri.fsPath;
+        const projectFile = path.join(folderPath, 'project.godot');
+        const godotVersion = await determineGodotVersionFromProjectFile(projectFile);
+        if (godotVersion) {
+            return godotVersion;
+        }
+    }
+
+    // A project folder was not provided or we couldn't determine the version from it.
+    // Try to find all the project.godot files in the workspace.
+    const projectFiles = await findProjectFiles();
+    if (projectFiles.length === 1) {
+        // We found exactly one project.godot file so we can assume this is the user's project
+        const godotVersion = await determineGodotVersionFromProjectFile(projectFiles[0].absoluteFilePath);
+        if (godotVersion) {
+            return godotVersion;
+        }
+    }
+
+    // We could not determine the Godot version
+    return undefined;
+}
+
+async function determineGodotVersionFromProjectFile(projectFilePath: string): Promise<string | undefined> {
+    if (!fs.existsSync(projectFilePath)) {
+        return undefined;
+    }
+
+    const projectFileStream = await fs.createReadStream(projectFilePath);
+    const rl = readline.createInterface({
+        input: projectFileStream,
+        crlfDelay: Infinity,
+    });
+
+    for await (const line of rl) {
+        if (line.startsWith('config_version=')) {
+            const configVersion = line.substr('config_version='.length);
+            switch (configVersion) {
+                case '4':
+                    return GODOT_VERSION_3;
+                case '5':
+                    return GODOT_VERSION_4;
+                default:
+                    return undefined;
+            }
+        }
+    }
+
+    return undefined;
+}
 
 export function fixPathForGodot(path: string): string {
     if (process.platform === "win32") {
@@ -17,12 +80,15 @@ export function fixPathForGodot(path: string): string {
     return path;
 }
 
-export async function findGodotExecutablePath(): Promise<string | undefined>
-{
+export async function findGodotExecutablePath(godotVersion: string): Promise<string | undefined> {
     let path: string | undefined;
 
     // If the user has set the path in the settings, use that value
-    path = Configuration.Value.godotExecutablePath;
+    if (semver.intersects(godotVersion, GODOT_VERSION_3)) {
+        path = Configuration.Value.godot3ExecutablePath;
+    } else if (semver.intersects(godotVersion, GODOT_VERSION_4)) {
+        path = Configuration.Value.godot4ExecutablePath;
+    }
     if (path) {
         return path;
     }


### PR DESCRIPTION
- Changes extension version to 0.3.0.
- Updates extension dependencies and add `semver` package.
- Add basic Godot version detection.
- Uses the `.mono` directory with Godot 3, and the `.godot/mono` directory with Godot 4.
- The `Play in Editor` configuration is unsupported in Godot 4.
- Generate standard coreclr debug configuration for Godot 4.
- The `-q` argument has been repurposed, now `--quit` should be used.
- Supersedes https://github.com/godotengine/godot-csharp-vscode/pull/39.
- Closes https://github.com/godotengine/godot-csharp-vscode/issues/38.

Since the extension uses the Mono debugger, for Godot 4 it just generates configuration to use the coreclr debugger (provided by the Omnisharp C# extension), which means it won't use the extension for debugging but at least it provides a convenient way to generate the configuration to debug a Godot game.

The _Play in Editor_ configuration won't be generated for Godot 4 projects since it doesn't work. And by this I mean, as long as the metadata file is read from the correct path (which is different in Godot 3 than in 4), and if the version handshake passes (the [`GodotTools.IdeMessaging`](https://www.nuget.org/packages/GodotTools.IdeMessaging) package likely needs to be updated, I tested with a local build), it builds and launches the game but the debugger won't attach since we are using Mono).

Other features such as the completion provider seem to work fine so until https://github.com/godotengine/godot-csharp-visualstudio/issues/18 is implemented, this would allow users to keep getting autocompletion from the extension.
